### PR TITLE
Change API spec for getting song info

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -6,12 +6,22 @@ from sqlalchemy.orm import Session
 from . import models
 
 
+# deprecated
 def get_song_by_date_and_music_chart(
     db: Session, date: datetime.date, music_chart_id: int
 ):
     return (
         db.query(models.Song)
         .filter(models.Song.music_chart_id == music_chart_id)
+        .filter(models.Song.base_date <= date)
+        .order_by(desc(models.Song.base_date))
+        .first()
+    )
+
+
+def get_song_by_date(db: Session, date: datetime.date):
+    return (
+        db.query(models.Song)
         .filter(models.Song.base_date <= date)
         .order_by(desc(models.Song.base_date))
         .first()

--- a/app/router.py
+++ b/app/router.py
@@ -11,10 +11,11 @@ router = APIRouter()
 
 @router.get(
     "/music-charts/{music_chart_id}/song",
-    description="날짜로 노래 조회",
-    response_model=schemas.FindSongResponse,
+    description="뮤직 차트 ID랑 날짜로 노래 조회 (삭제 예정)",
+    response_model=schemas.GetSongResponseDeprecated,
+    deprecated=True,
 )
-def get_song(
+def get_song_deprecated(
     music_chart_id: int = Path(..., title="뮤직 차트 ID", example=1),
     date: datetime.date = Query(..., title="조회할 날짜", example="1995-05-03"),
     db: Session = Depends(get_db),
@@ -23,6 +24,26 @@ def get_song(
         db=db,
         date=date,
         music_chart_id=music_chart_id,
+    )
+    if db_song is None:
+        raise HTTPException(status_code=404, detail="Song not found")
+    return db_song
+
+
+@router.get(
+    "/songs/{year}/{month}/{day}",
+    description="특정 날짜에 1위한 노래 조회",
+    response_model=schemas.GetSongResponse,
+)
+def get_song(
+    year: int = Path(..., ge=1981, le=2023, title="조회할 년도", example=1995),
+    month: int = Path(..., ge=1, le=12, title="조회할 월", example=5),
+    day: int = Path(..., ge=1, le=31, title="조회할 일", example=3),
+    db: Session = Depends(get_db),
+):
+    db_song = crud.get_song_by_date(
+        db=db,
+        date=datetime.date(year, month, day),
     )
     if db_song is None:
         raise HTTPException(status_code=404, detail="Song not found")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,17 +1,33 @@
 from datetime import date
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
 
-class FindSongResponse(BaseModel):
+class MusicChart(BaseModel):
+    id: int = Field(..., description="뮤직 차트 ID", example="1")
+    name: str = Field(..., description="뮤직 차트 이름", example="가요톱10")
+
+    class Config:
+        from_attributes = True
+
+
+class Song(BaseModel):
     id: int = Field(..., description="노래 ID", example="1")
     title: str = Field(..., description="노래 제목", example="촛불")
     artist: str = Field(..., description="노래 가수", example="조용필")
     base_date: date = Field(..., description="차트 기준일", example="1995-01-01")
-    youtube_video_id: str = Field(
-        ..., nullable=True, description="유튜브 비디오 ID", example="M7lc1UVf-VE"
+    youtube_video_id: Optional[str] = Field(
+        ..., description="유튜브 비디오 ID", example="M7lc1UVf-VE"
     )
-    music_chart_id: int = Field(..., description="뮤직 차트 ID", example="1")
 
     class Config:
         from_attributes = True
+
+
+class GetSongResponseDeprecated(Song):
+    music_chart_id: int = Field(..., description="뮤직 차트 ID", example="1")
+
+
+class GetSongResponse(Song):
+    music_chart: MusicChart = Field(..., description="뮤직 차트 정보")


### PR DESCRIPTION
**수정 사항**
- 특정 날짜의 노래 조회 API 스펙 변경 (이전 API는 FE 수정하면 나중에 삭제 예정)
  - 엔드포인트/요청 스펙 변경
    - AS-IS: `GET /music-charts/{music_chart_id}/song`
    - TO-BE: `GET /songs/{year}/{month}/{day}`
  - 응답 스펙 변경
    - (요구사항) 뮤직차트 정보 추가

**요청 예시 (둘다 가능)**
```http
GET /songs/1995/5/3
GET /songs/1995/05/03 
```

**응답 예시**
```json
{
  "id": 1,
  "title": "촛불",
  "artist": "조용필",
  "base_date": "1995-01-01",
  "youtube_video_id": "M7lc1UVf-VE",
  "music_chart": { # 뮤직차트 정보 추가
    "id": 1,
    "name": "가요톱10"
  }
}
```